### PR TITLE
feat: Filtering & watching by subcalls

### DIFF
--- a/bin/cmd/tx.rs
+++ b/bin/cmd/tx.rs
@@ -113,6 +113,8 @@ impl TxArgs {
             value: None,
             reversed_order: self.reverse,
             top_metadata: self.top_metadata,
+            match_calls: vec![],
+            show_calls: false,
         };
 
         let ens_lookup_mode = if shared_deps.chain.chain_type == EVMChainType::Mainnet {

--- a/src/models/mev_block.rs
+++ b/src/models/mev_block.rs
@@ -318,15 +318,17 @@ impl MEVBlock {
 
         self.ingest_logs(filter, sqlite, symbols_lookup, provider)
             .await?;
-        self.non_trace_filter_txs(filter).await?;
 
+        // within trace functions method filtering applies to subcalls
         match conn_opts.trace {
             Some(TraceMode::RPC) => self.trace_txs_rpc(filter, sqlite, provider).await?,
             Some(TraceMode::Revm) => {
                 self.trace_txs_revm(filter, revm_db.expect("Revm must be present"))
                     .await?
             }
-            _ => {}
+            _ => {
+                self.non_trace_filter_txs(filter).await?;
+            }
         };
 
         Ok(())

--- a/src/models/mev_block.rs
+++ b/src/models/mev_block.rs
@@ -472,7 +472,7 @@ impl MEVBlock {
                 revm_db,
             )?;
 
-            println!("calls: {:?}", calls);
+            println!("calls: {calls:?}");
 
             let coinbase_transfer = find_coinbase_transfer(
                 self.revm_context.coinbase,

--- a/src/models/mev_block.rs
+++ b/src/models/mev_block.rs
@@ -32,7 +32,9 @@ use crate::{
         shared_init::{ConnOpts, EVMChain, TraceMode},
         symbol_utils::SymbolLookupWorker,
         utils::{ToU64, ETH_TRANSFER, SEPARATORER, UNKNOWN},
-    }, models::mev_transaction::{extract_signature, CallExtract}, GenericProvider
+    },
+    models::mev_transaction::{extract_signature, CallExtract},
+    GenericProvider,
 };
 
 #[derive(Clone, Debug)]
@@ -360,7 +362,8 @@ impl MEVBlock {
             let mut call_extracts = Vec::new();
             for call in calls.clone() {
                 if let Some(to) = call.to {
-                    let (signature_hash, signature) = extract_signature(&self.chain, Some(&call.input), tx_index, sqlite).await?;
+                    let (signature_hash, signature) =
+                        extract_signature(&self.chain, Some(&call.input), tx_index, sqlite).await?;
                     call_extracts.push(CallExtract {
                         from: call.from,
                         to,

--- a/src/models/mev_transaction.rs
+++ b/src/models/mev_transaction.rs
@@ -78,6 +78,7 @@ pub struct MEVTransaction {
     pub receipt: ReceiptData,
     pub top_metadata: bool,
     pub calls: Option<Vec<CallExtract>>,
+    pub show_calls: bool,
 }
 
 // CSV row:
@@ -151,6 +152,7 @@ impl MEVTransaction {
         ens_lookup: &ENSLookup,
         provider: &Arc<GenericProvider>,
         top_metadata: bool,
+        show_calls: bool,
     ) -> Result<Self> {
         let (signature_hash, signature) =
             extract_signature(&chain, tx_req.input.input.as_ref(), index, sqlite).await?;
@@ -174,6 +176,7 @@ impl MEVTransaction {
             receipt: receipt_data,
             top_metadata,
             calls: None,
+            show_calls,
         })
     }
 
@@ -327,13 +330,15 @@ impl fmt::Display for MEVTransaction {
             writeln!(f, "{}", "Tx reverted!".red().bold())?;
         }
 
-        if let Some(calls) = &self.calls {
-            writeln!(f, "{SEPARATOR}")?;
-            writeln!(f, "Calls:")?;
-            for call in calls {
-                writeln!(f, "{call}")?;
+        if self.show_calls {
+            if let Some(calls) = &self.calls {
+                writeln!(f, "{SEPARATOR}")?;
+                writeln!(f, "Calls:")?;
+                for call in calls {
+                    writeln!(f, "{call}")?;
+                }
+                writeln!(f, "{SEPARATOR}")?;
             }
-            writeln!(f, "{SEPARATOR}")?;
         }
 
         writeln!(

--- a/src/models/mev_transaction.rs
+++ b/src/models/mev_transaction.rs
@@ -261,7 +261,7 @@ pub async fn extract_signature(
 ) -> Result<(Option<String>, String), eyre::Error> {
     let signature_hash = {
         if let Some(input) = input {
-            if input.len() >= 8 {
+            if input.len() >= 4 {
                 let hash = format!("0x{}", hex::encode(&input[..4]));
                 Some(hash)
             } else {

--- a/src/models/mev_transaction.rs
+++ b/src/models/mev_transaction.rs
@@ -47,7 +47,16 @@ pub struct CallExtract {
 
 impl fmt::Display for CallExtract {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} -> {}::{} ({})", format!("{}", self.from).yellow(), format!("{}",self.to).green(), self.signature.purple(), self.signature_hash.as_ref().unwrap_or(&"no signature found".to_string()))?;
+        write!(
+            f,
+            "{} -> {}::{} ({})",
+            format!("{}", self.from).yellow(),
+            format!("{}", self.to).green(),
+            self.signature.purple(),
+            self.signature_hash
+                .as_ref()
+                .unwrap_or(&"no signature found".to_string())
+        )?;
         Ok(())
     }
 }
@@ -143,7 +152,8 @@ impl MEVTransaction {
         provider: &Arc<GenericProvider>,
         top_metadata: bool,
     ) -> Result<Self> {
-        let (signature_hash, signature) = extract_signature(&chain, tx_req.input.input.as_ref(), index, sqlite).await?;
+        let (signature_hash, signature) =
+            extract_signature(&chain, tx_req.input.input.as_ref(), index, sqlite).await?;
 
         let mev_address =
             MEVAddress::new(tx_req.from.expect("TX from missing"), ens_lookup, provider).await?;
@@ -243,7 +253,12 @@ impl MEVTransaction {
     }
 }
 
-pub async fn extract_signature(chain: &EVMChain, input: Option<&Bytes>, index: u64, sqlite: &sqlx::Pool<sqlx::Sqlite>) -> Result<(Option<String>, String), eyre::Error> {
+pub async fn extract_signature(
+    chain: &EVMChain,
+    input: Option<&Bytes>,
+    index: u64,
+    sqlite: &sqlx::Pool<sqlx::Sqlite>,
+) -> Result<(Option<String>, String), eyre::Error> {
     let signature_hash = {
         if let Some(input) = input {
             if input.len() >= 8 {

--- a/src/models/mev_transaction.rs
+++ b/src/models/mev_transaction.rs
@@ -37,6 +37,21 @@ pub struct ReceiptData {
     pub gas_used: u64,
 }
 
+#[derive(Debug, Clone)]
+pub struct CallExtract {
+    pub from: Address,
+    pub to: Address,
+    pub signature: String,
+    pub signature_hash: Option<String>,
+}
+
+impl fmt::Display for CallExtract {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} -> {}::{} ({})", format!("{}", self.from).yellow(), format!("{}",self.to).green(), self.signature.purple(), self.signature_hash.as_ref().unwrap_or(&"no signature found".to_string()))?;
+        Ok(())
+    }
+}
+
 #[derive(Debug)]
 pub struct MEVTransaction {
     native_token_price: f64,
@@ -53,6 +68,7 @@ pub struct MEVTransaction {
     pub coinbase_transfer: Option<U256>,
     pub receipt: ReceiptData,
     pub top_metadata: bool,
+    pub calls: Option<Vec<CallExtract>>,
 }
 
 // CSV row:
@@ -127,32 +143,7 @@ impl MEVTransaction {
         provider: &Arc<GenericProvider>,
         top_metadata: bool,
     ) -> Result<Self> {
-        let signature_hash = if let Some(input) = tx_req.clone().input.input {
-            if input.len() >= 8 {
-                let hash = format!("0x{}", hex::encode(&input[..4]));
-                Some(hash)
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        let signature = match signature_hash.clone() {
-            Some(sig) => {
-                // TODO refactor
-                if chain.chain_type == EVMChainType::Base
-                    && index == 0
-                    && signature_hash == Some("0x098999be".to_string())
-                {
-                    "setL1BlockValuesIsthmus()".to_string()
-                } else {
-                    let sig = DBMethod::find_by_hash(&sig, sqlite).await?;
-                    sig.unwrap_or(UNKNOWN.to_string())
-                }
-            }
-            None => ETH_TRANSFER.to_string(),
-        };
+        let (signature_hash, signature) = extract_signature(&chain, tx_req.input.input.as_ref(), index, sqlite).await?;
 
         let mev_address =
             MEVAddress::new(tx_req.from.expect("TX from missing"), ens_lookup, provider).await?;
@@ -172,6 +163,7 @@ impl MEVTransaction {
             coinbase_transfer: None,
             receipt: receipt_data,
             top_metadata,
+            calls: None,
         })
     }
 
@@ -251,6 +243,37 @@ impl MEVTransaction {
     }
 }
 
+pub async fn extract_signature(chain: &EVMChain, input: Option<&Bytes>, index: u64, sqlite: &sqlx::Pool<sqlx::Sqlite>) -> Result<(Option<String>, String), eyre::Error> {
+    let signature_hash = {
+        if let Some(input) = input {
+            if input.len() >= 8 {
+                let hash = format!("0x{}", hex::encode(&input[..4]));
+                Some(hash)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    };
+    let signature = match signature_hash.clone() {
+        Some(sig) => {
+            // TODO refactor
+            if chain.chain_type == EVMChainType::Base
+                && index == 0
+                && signature_hash == Some("0x098999be".to_string())
+            {
+                "setL1BlockValuesIsthmus()".to_string()
+            } else {
+                let sig = DBMethod::find_by_hash(&sig, sqlite).await?;
+                sig.unwrap_or(UNKNOWN.to_string())
+            }
+        }
+        None => ETH_TRANSFER.to_string(),
+    };
+    Ok((signature_hash, signature))
+}
+
 impl fmt::Display for MEVTransaction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if !self.top_metadata {
@@ -287,6 +310,15 @@ impl fmt::Display for MEVTransaction {
 
         if !self.receipt.success {
             writeln!(f, "{}", "Tx reverted!".red().bold())?;
+        }
+
+        if let Some(calls) = &self.calls {
+            writeln!(f, "{SEPARATOR}")?;
+            writeln!(f, "Calls:")?;
+            for call in calls {
+                writeln!(f, "{call}")?;
+            }
+            writeln!(f, "{SEPARATOR}")?;
         }
 
         writeln!(

--- a/src/models/txs_filter.rs
+++ b/src/models/txs_filter.rs
@@ -56,13 +56,12 @@ pub struct SharedFilterOpts {
     pub method: Option<String>,
 
     #[arg(
-        alias = "cls",
         long,
         help = "Include txs by subcalls method names matching the provided regex, signature or signature hash"
     )]
     pub calls: Vec<String>,
 
-    #[arg(alias = "sc", long, help = "Show detailed tx calls info")]
+    #[arg(long, help = "Show detailed tx calls info")]
     pub show_calls: bool,
 
     #[arg(

--- a/src/models/txs_filter.rs
+++ b/src/models/txs_filter.rs
@@ -47,12 +47,23 @@ pub struct SharedFilterOpts {
         help = "Exclude txs by event names matching the provided regex or signature and optionally an address"
     )]
     pub not_event: Option<String>,
+
     #[arg(
         alias = "m",
         long,
         help = "Include txs by root method names matching the provided regex, signature or signature hash"
     )]
     pub method: Option<String>,
+
+    #[arg(
+        alias = "cls",
+        long,
+        help = "Include txs by subcalls method names matching the provided regex, signature or signature hash"
+    )]
+    pub calls: Vec<String>,
+
+    #[arg(alias = "sc", long, help = "Show detailed tx calls info")]
+    pub show_calls: bool,
 
     #[arg(
         alias = "tc",
@@ -176,6 +187,8 @@ pub struct TxsFilter {
     pub events: Vec<EventQuery>,
     pub not_events: Vec<EventQuery>,
     pub match_method: Option<SignatureQuery>,
+    pub match_calls: Vec<SignatureQuery>,
+    pub show_calls: bool,
     pub tx_cost: Option<PriceQuery>,
     pub real_tx_cost: Option<PriceQuery>,
     pub gas_price: Option<PriceQuery>,
@@ -261,6 +274,12 @@ impl TxsFilter {
                 Some(ref query) => Some(query.parse()?),
                 None => None,
             },
+            match_calls: filter_opts
+                .calls
+                .iter()
+                .map(|query| query.parse())
+                .collect::<Result<Vec<_>>>()?,
+            show_calls: filter_opts.show_calls,
             reversed_order: filter_opts.reverse,
             top_metadata: filter_opts.top_metadata,
         })
@@ -297,20 +316,19 @@ impl TxsFilter {
             }
         }
 
-        if let Some(method) = &self.match_method {
+        if !self.match_calls.is_empty() {
             if let Some(calls) = &mev_tx.calls {
-                for call in calls {
-                    if method.matches(&call.signature) {
-                        return false;
-                    }
-                    if let Some(signature_hash) = &call.signature_hash {
-                        if method.matches(signature_hash) {
-                            return false;
-                        }
-                    }
+                let any_call_matches = calls.iter().any(|call| {
+                    self.match_calls
+                        .iter()
+                        .any(|query| query.matches(&call.signature))
+                });
+                if !any_call_matches {
+                    return true;
                 }
+            } else {
+                return true;
             }
-            return true;
         }
 
         false

--- a/src/models/txs_filter.rs
+++ b/src/models/txs_filter.rs
@@ -297,8 +297,8 @@ impl TxsFilter {
             }
         }
 
-        if let Some(calls) = &mev_tx.calls {
-            if let Some(method) = &self.match_method {
+        if let Some(method) = &self.match_method {
+            if let Some(calls) = &mev_tx.calls {
                 for call in calls {
                     if method.matches(&call.signature) {
                         return false;

--- a/src/models/txs_filter.rs
+++ b/src/models/txs_filter.rs
@@ -297,6 +297,17 @@ impl TxsFilter {
             }
         }
 
+        if let Some(calls) = &mev_tx.calls {
+            if let Some(method) = &self.match_method {
+                for call in calls {
+                    if method.matches(&call.signature) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
         false
     }
 

--- a/src/models/txs_filter.rs
+++ b/src/models/txs_filter.rs
@@ -303,6 +303,11 @@ impl TxsFilter {
                     if method.matches(&call.signature) {
                         return false;
                     }
+                    if let Some(signature_hash) = &call.signature_hash {
+                        if method.matches(signature_hash) {
+                            return false;
+                        }
+                    }
                 }
             }
             return true;


### PR DESCRIPTION
Addresses https://github.com/pawurb/mevlog-rs/issues/16

First working draft. Will still add filtering support and enable subcall printing only if --method is set not to disrupt current workflow (or should we add a new option to trigger this functionality?). 
When I try to use revm tracing the calls variable seems empty, so doing now only for 'rpc' mode. 
I'm mostly interested in 'watch' flow, so it might break others.

Comments welcome!